### PR TITLE
Fix bound properties with setter functions

### DIFF
--- a/src/dtx/widget/BuildTools.hx
+++ b/src/dtx/widget/BuildTools.hx
@@ -310,8 +310,8 @@ class BuildTools
         {
             case FieldType.FProp(get, set, t, _):
                 // Read the getter / setter string, in case it already exists and was different
-                getterString = get;
-                setterString = set;
+                if (get != "get") getterString = get;
+                if (set != "set") setterString = set;
                 propertyType = t;
             case FieldType.FVar(type,expr):
                 // This was originally a function or a var, change it to a property


### PR DESCRIPTION
I believe this small change fixes a bug where expressions in a detox template don't work if the left-most property of the expression is already defined as a property with a setter function. As far as I can tell it would have broken with haxe 3 (when support for custom accessor function names was removed).

This fixes it for me in haxe 3.1.3, and I hope with the if statements it should continue to work for custom accessor functions in haxe 2, but I haven't tested that.